### PR TITLE
ring-ssh

### DIFF
--- a/scripts/ring-ssh
+++ b/scripts/ring-ssh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Written by Martin Pels <martin@rodecker.nl>
 # Improved by Miek Gieben <miek@miek.nl>
-
+set -e
 if [ $# -eq 0 ]; then
     echo $0: need ssh command line >&2
     exit 1


### PR DESCRIPTION
The ring-ssh script was not working for us - so I changed it a little. It now correctly uses eval to execute the ssh-agent. It also honors $TMPDIR and uses more sane (YMMV) names.
