### PR TITLE
Update ring-ping

### DIFF
--- a/scripts/ring-ping
+++ b/scripts/ring-ping
@@ -96,7 +96,7 @@ else
 	exit 1
 fi
 
-ping_cmd="echo '\$(hostname -s)': '\$(${ping} -c1 -W1 $host | grep ^rtt)'"
+ping_cmd="echo '\$(hostname -s)': '\$(${ping} -c1 -W1 $host | grep ^rtt)' :'\$(grep Location /etc/motd|cut -d: -f2)'"
 ssh_cmd="ssh -q -o ConnectTimeout=2 {}.ring.nlnog.net ${ping_cmd}" 
 
 SERVERS=$(dig -t txt +short ring.nlnog.net | grep -v '^;' | tr -d '"' | tr ' ' '\n')
@@ -121,7 +121,8 @@ while read line; do
     if [ -n "${output}" ]; then
 	time=`echo $output | cut -f6 -d/`
 	replies=( ${replies[@]} ${time} )
-	[ -n "${verbose}" ] && printf "%-30s %s\n" ${server}: $time
+	info=`echo $output | cut -f2- -d:`
+	[ -n "${verbose}" ] && printf "%-30s %-30s %s %s\n" ${server}: $time "$info"
     else
 	timeouts=( ${timeouts[@]} $server )
 	[ -n "${verbose}" ] && printf "%-20s %s\n" ${server}: timeout


### PR DESCRIPTION
Add extended description (from /etc/motd) for server line like:

tfskok@tfskok01:~$ ./ring-ping -v -n60 91.212.242.242
coloclue01:                    31.171
widexs01:                      36.088                          Netherlands - AS15879 (ripencc, ASN-IS IS Group B.V.,NL)
intouch01:                     35.407                          Netherlands - AS8935 (ripencc, INTOUCH-INT-AS InTouch N.V.,NL)
previder01:                    32.787                          Netherlands - AS20847 (ripencc, PREVIDER-AS Previder B.V.,NL)
duocast01:                     38.251                          Netherlands - AS31477 (ripencc, DUOCAST-AS Duocast B.V.,NL)
leaseweb01:                    31.100                          Netherlands - AS60781 (ripencc, LEASEWEB-NL LeaseWeb B.V.,NL)
interconnect01:                37.539                          Netherlands - AS9150 (ripencc, INTERCONNECT ML Consultancy,NL)
cambrium01:                    35.722                          Netherlands - AS25596 (ripencc, CAMBRIUM-AS Cambrium IT Services B.V.,NL)
oxilion01:                     37.344                          Netherlands - AS48539 (ripencc, OXILION-AS Oxilion B.V.,NL)
cyso01:                        36.179                          Netherlands - AS25151 (ripencc, CYSO-AS Cyso Hosting B.V.,NL)
ebayclassifiedsgroup01:        35.132                          Netherlands - AS41552 (ripencc, MARKTPLAATS-AS Marktplaats B.V.,NL)
prolocation01:                 35.497                          Netherlands - AS41887 (ripencc, PROLOCATION Prolocation AS,NL)
surfnet01:                     36.228                          Netherlands - AS1103 (ripencc, SURFNET-NL SURFnet, The Netherlands,NL)
in2ip01:                       36.736                          Netherlands - AS34141 (ripencc, IN2IP-AS in2ip B.V. i.o.,NL)
xs4all01:                      30.207                          Netherlands - AS3265 (ripencc, XS4ALL-NL XS4ALL Internet BV,NL)