### PR TITLE
Bug Fix

### DIFF
--- a/scripts/ring-ping
+++ b/scripts/ring-ping
@@ -122,7 +122,7 @@ while read line; do
 
     results=( ${results[@]} ${server} )
 
-    if [ -n "${output}" ]; then
+    if [[ ${output} = *rtt* ]]; then
 	time=`echo $output | cut -f6 -d/`
 	replies=( ${replies[@]} ${time} )
 	info=`echo $output | cut -f2- -d:`


### PR DESCRIPTION
To prevent error like this (on unrechable host):

tfskok@tfskok01:~$ ./ring-ping -v -n16 2001:67c:24c::b
nynex01:                       39.045                          Germany - AS62023 (ripencc, NYNEX NYNEX satellite OHG,DE)
mknetzdienste01:               28.629                          Germany - AS25394 (ripencc, MK-NETZDIENSTE-AS MK Netzdienste GmbH & Co. KG,DE)
noris01:                       31.315                          Germany - AS12337 (ripencc, NORIS-NETWORK noris network AG,DE)
dacor01:                       41.538                          Germany - AS28876 (ripencc, SUEC-DACOR-AS suec // dacor GmbH,DE)
businessconnect01:             35.075                          Netherlands - AS15693 (ripencc, BUSINESSCONNECT BusinessConnect B.V.,NL)
suretec01:                     36.651                          United Kingdom - AS199659 (ripencc, SURETEC Suretec Systems Limited,GB)
icanndns02:                    109.302                         Virginia, United States - AS16876 (arin, ICANN-DC - ICANN,US)
blizoo01:                      61.561                          Bulgaria - AS13124 (ripencc, IBGC Blizoo Media and Broadband EAD,BG)
icanndns01:                    174.697                         California, United States - AS;;
viatel03:                      36.610                          United Kingdom - AS31122 (ripencc, DIGIWEB-AS Digiweb Ltd.,IE)
sixdegrees01:                  43.043                          United Kingdom - AS6908 (ripencc, DATAHOP Six Degrees Managed Data Limited,GB)
atw01:                         45.729                          Hungary - AS41075 (ripencc, ATW-AS ATW Internet Kft.,HU)
vibe01:                        300.445                         New Zealand - AS45177 (apnic, LAYER2CO-AS-AP Layer2.co.nz,NZ)
networkoperations01:           :                              Netherlands -
AS30830                        (ripencc,                      HSCG-AS CrossOver
Data                           B.V,NL)                         Netherlands - AS30830 (ripencc, HSCG-AS CrossOver Data B.V,NL)
(standard_in) 1: illegal character: :
(standard_in) 2: syntax error
(standard_in) 1: syntax error
(standard_in) 1: illegal character: N
(standard_in) 1: syntax error
(standard_in) 1: syntax error
(standard_in) 1: illegal character: S
(standard_in) 1: syntax error
(standard_in) 1: syntax error
(standard_in) 1: illegal character: H
(standard_in) 1: illegal character: S
(standard_in) 1: illegal character: G
(standard_in) 1: illegal character: S
(standard_in) 1: syntax error
(standard_in) 1: illegal character: O
(standard_in) 1: syntax error
(standard_in) 1: syntax error
(standard_in) 1: illegal character: V
(standard_in) 1: illegal character: N
(standard_in) 1: illegal character: L
(standard_in) 1: syntax error
22 servers: ms average
ssh connection failed: bogalnet01 cloudnl01
tfskok@tfskok01:~$ mc

apply this patch....
Sorry.