### PR TITLE
Add "fail situation" counter

### DIFF
--- a/scripts/ring-ping
+++ b/scripts/ring-ping
@@ -144,9 +144,12 @@ if [ -n "${replies[*]}" ]; then
     echo ${#replies[@]} servers: ${avg}ms average
 fi
 
-[ -z "${timeouts[*]}" ] || echo unreachable via: ${timeouts[@]}
+uc=`(echo ${timeouts[*]} | tr ' ' '\n' | wc -l)`
+[ -z "${timeouts[*]}" ] || echo $uc unreachable via: ${timeouts[@]}
 
 connect=$(comm -23 <(echo "${SERVERS}" | sort) \
     <(echo ${results[@]} | tr ' ' '\n' | sort))
-[ -z "${connect[*]}" ] || echo ssh connection failed: ${connect[@]}
+    
+cc=`(echo ${connect[*]} | tr ' ' '\n' | wc -l)`
+[ -z "${connect[*]}" ] || echo $cc ssh connection failed: ${connect[@]}
 


### PR DESCRIPTION
Add "fail situation" counter for "ssh connection fail" and "unreachable".

Old behaviour:
...
123 servers: 77ms average
unreachable via: onlinesas01
ssh connection failed: antagonist01 blacknight01 cloudnl01 fullsave01 heanet01 i3d01 inerail01 nautile01 ovh01 ualbany01

new behaviour:
...
123 servers: 77ms average
1 unreachable via: onlinesas01
10 ssh connection failed: antagonist01 blacknight01 cloudnl01 fullsave01 heanet01 i3d01 inerail01 nautile01 ovh01 ualbany01