### PR TITLE
Fix to prevent $SHELL mis-detection

### DIFF
--- a/scripts/ring-ssh
+++ b/scripts/ring-ssh
@@ -20,7 +20,7 @@ if [ ! -d $(dirname $SSH_AUTH_SOCK) ]; then
 fi
 if [ ! -S $SSH_AUTH_SOCK ];
 then 
-    eval $(ssh-agent -a $SSH_AUTH_SOCK)
+    eval $(ssh-agent -s -a $SSH_AUTH_SOCK)
     ssh-add -D
     ssh-add $keyfile
 fi


### PR DESCRIPTION
If your interactive shell is a c-shell variant `ssh-agent` will detect that in `$SHELL` and output `setenv FOO=bar` syntax instead of Bourne Shell syntax.   Supplying the `-s` option forces it to output the correct syntax.